### PR TITLE
fix: DateTimePickerModalがDark Modeでテキストを表示しないバグの修正

### DIFF
--- a/components/RegisterView.tsx
+++ b/components/RegisterView.tsx
@@ -118,6 +118,8 @@ const RegisterView: React.VFC = () => {
                     cancelTextIOS='キャンセル'
                     date={date}
                     onChange={(date) => field.onChange(date)}
+                    textColor='black'
+                    pickerContainerStyleIOS={styles.pickerContainerStyleIOS}
                   />
                   <Text style={styles.dateText}>
                     {dayjs(date).format('YYYY年MM月DD日')}
@@ -229,6 +231,9 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     backgroundColor: '#59C3C3',
     justifyContent: 'center',
+  },
+  pickerContainerStyleIOS: {
+    backgroundColor: 'white',
   },
   dateForm: {
     flex: 2,


### PR DESCRIPTION
概要
`DateTimePickerModal`がシミュレーター上では正しく機能するのに実機(iPhone 12 iOS14.5)では日を表示しないバグを発見
原因はiPhoneのDark Mode。シミュレーター上での再現も確認
修正方法として、本アプリ上では常にLight Mode使用のモーダルを表示するように変更