### PR TITLE
fix: マウント時に空データが登録される不具合の修正

### DIFF
--- a/components/List.tsx
+++ b/components/List.tsx
@@ -164,7 +164,8 @@ const List = () => {
     if (wordList !== undefined) {
       console.log('wordlist')
       console.log(wordList)
-      // 検索ヒットした全ての用語に対してタグを取得するためにtag_map_tableから登録されているtagIDを取得
+      // 検索ヒットした全ての用語に対してタグを取得する
+      // まずtag_map_tableから登録されているtagIDを取得
       for (let i = 0; i < wordList.length; i++) {
         tmt.transaction((tmt_tx) => {
           tmt_tx.executeSql(
@@ -180,6 +181,7 @@ const List = () => {
             }
           )
         })
+        // tag_tableからtagIDを用いてtagの取得
       }
     }
   }, [wordList])


### PR DESCRIPTION
<事象>
tagsとtag_mapにデータが勝手に追加されることがある

<原因>
useEffectの中でデータ追加処理を行なっていたが、componentDidMountのタイミングで意図せず登録処理が走っていた

<対処>
useEffectの中のデータ追加処理を、初期値が設定されている時は動かないように修正